### PR TITLE
Fix vds file opening because of invalid hardlink

### DIFF
--- a/epsic_tools/mib2hdfConvert/MIB_convert_widget/scripts/MIB_convert_submit.py
+++ b/epsic_tools/mib2hdfConvert/MIB_convert_widget/scripts/MIB_convert_submit.py
@@ -442,6 +442,8 @@ def write_vds(source_h5_path, writing_h5_path, entry_key='Experiments/__unnamed_
             f.create_virtual_dataset(vds_key, layout)
             f['/data/mask'] = h5py.ExternalLink('/dls_sw/e02/medipix_mask/Merlin_12bit_mask.h5', "/data/mask")
             f['metadata']['4D_shape'] = tuple(sh)
+            # this points to invalid link in Windows, removing it
+            del f['/experiment:NXentry']
         
     return
 


### PR DESCRIPTION
This PR fixes the issue of vds file opening, as the source metadata file contains a hardlink in Windows (probably from the control machine?), and this is not valid in dls file system.

I selected one random file to illustrate the issue:
1. I can't open `cm40603-2/processing/Merlin/Practice_session/20250311_130550/20250311_130550.hdf` in DAWN
2. the metadata source file `cm40603-2/Merlin/Practice_session/20250311_130550.hdf` has a group `/experiment:NXentry`, which points to `X:\data\2025\cm40603-2\Merlin\Ptycho_Tomo_TiO2\20250311_130550._data.hdf`, which is not valid.
3. You can use `h5dump -n <DLS_PATH>/cm40603-2/Merlin/Practice_session/20250311_130550.hdf` to check the group/dataset in the files.

After this fix the vds file should be opened without error in DAWN. 

I [have fixed this in the container version](https://github.com/ePSIC-DLS/mib2x-crt/commit/6792fb98f7599c337fb40bd88083fe8794e26aed) (for testing in the workflow system) some time ago but forgot to communicate this to the production version.